### PR TITLE
update unit tests for ini state

### DIFF
--- a/tests/unit/states/ini_manage_test.py
+++ b/tests/unit/states/ini_manage_test.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 # Import Salt Testing Libs
 from salttesting import skipIf, TestCase
 from salttesting.mock import (
+    MagicMock,
     NO_MOCK,
     NO_MOCK_REASON,
     patch)
@@ -48,10 +49,14 @@ class IniManageTestCase(TestCase):
             ret.update({'comment': comt})
             self.assertDictEqual(ini_manage.options_present(name), ret)
 
-        with patch.dict(ini_manage.__opts__, {'test': False}):
-            comt = ('No anomaly detected')
-            ret.update({'comment': comt, 'result': True})
-            self.assertDictEqual(ini_manage.options_present(name), ret)
+        changes = {'first': 'who is on',
+                   'second': 'what is on',
+                   'third': "I don't know"}
+        with patch.dict(ini_manage.__salt__, {'ini.set_option': MagicMock(return_value=changes)}):
+            with patch.dict(ini_manage.__opts__, {'test': False}):
+                comt = ('Changes take effect')
+                ret.update({'comment': comt, 'result': True, 'changes': changes})
+                self.assertDictEqual(ini_manage.options_present(name), ret)
 
     # 'options_absent' function tests: 1
 
@@ -97,10 +102,14 @@ class IniManageTestCase(TestCase):
             ret.update({'comment': comt})
             self.assertDictEqual(ini_manage.sections_present(name), ret)
 
-        with patch.dict(ini_manage.__opts__, {'test': False}):
-            comt = ('No anomaly detected')
-            ret.update({'comment': comt, 'result': True})
-            self.assertDictEqual(ini_manage.sections_present(name), ret)
+        changes = {'first': 'who is on',
+                   'second': 'what is on',
+                   'third': "I don't know"}
+        with patch.dict(ini_manage.__salt__, {'ini.set_option': MagicMock(return_value=changes)}):
+            with patch.dict(ini_manage.__opts__, {'test': False}):
+                comt = ('Changes take effect')
+                ret.update({'comment': comt, 'result': True, 'changes': changes})
+                self.assertDictEqual(ini_manage.sections_present(name), ret)
 
     # 'sections_absent' function tests: 1
 


### PR DESCRIPTION
Hopefully these changes make sense.  The loader does not create `__salt__`, etc. for unit test code, so they need to be created by hand, which is probably a good thing.
